### PR TITLE
add full output tar link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ least setting environment variables PDK_ROOT, PDK, and PRECHECK_ROOT.
 If the PDK is installed with open_pdks, then PRECHECK_ROOT can be set
 to open_pdks/sources/precheck_sky130.
 
+This might take an hour. If you just want to see the results then you
+can download [a tar of the full output](https://github.com/qpwo/_patch_chipalooza_projects_1/releases/tag/build4d31885)
+
 Testing:
 
 All projects are connected either to the logic analyzer (128 I/O bits) or


### PR DESCRIPTION
Hey feel free to drop this if you oppose ---

Since the precheck takes so long and people (like me) are using this as reference material, might be helpful to have a full tar of the built repo with all the sources and stuff so you can just download it and browse even if the tooling changes or your system is somehow in a broken state.

I am using github's releases thing to host the file. I guess you might want to download the tar and re-upload to the releases here on this repo